### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [0.1.1](https://github.com/globe-and-citizen/layer8-primitives-rs/releases/tag/v0.1.1) - 2025-01-10
+
+### Fixed
+
+- fix build
+
+### Other
+
+- nxt version
+- using best compression
+- api rename
+- using base64 as io
+- lint&fmt
+- specificity to not snipe the API
+- linting code
+- gzip compression
+- with tests
+- forward host header fix
+- parse static payload uniformly
+- redesign
+- rename to uri
+- url path is part of encrypted
+- propagate url query
+- envelope as pub api
+- rm if cond on workflow
+- relase updates
+- name refactor
+- release-plz toml
+- carates io publish workflow
+- quality gate
+- initial commit
+
 ## [v0.1.1] - 2025-01-10
 
 ### Added


### PR DESCRIPTION
## 🤖 New release
* `layer8-primitives`: 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).