### PR TITLE
chore: provide js feat for transient dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,6 +740,7 @@ dependencies = [
  "aes-gcm",
  "base64 0.22.1",
  "flate2",
+ "getrandom",
  "http",
  "http-body-util",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ aes-gcm = "0.10.3"
 uuid = { version = "1", features = ["js", "v4", "fast-rng"] }
 flate2 = { version = "1" }
 
-
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies] # Transient dependency for [`aes-gcm@0.10.3`]
 getrandom = { version = "0.2", features = ["js"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ aes-gcm = "0.10.3"
 uuid = { version = "1", features = ["js", "v4", "fast-rng"] }
 flate2 = { version = "1" }
 
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies] # Transient dependency for [`aes-gcm@0.10.3`]
+getrandom = { version = "0.2", features = ["js"] }
+
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 jsonwebtoken = "9"


### PR DESCRIPTION
Fixing issues for the upstream libs that depend on it for the wasm32 target arch.
We are providing the guarantee that `layer8-primitives-rs` will always be compatible with wasm32 target out of the box