### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/globe-and-citizen/layer8-primitives-rs/compare/v0.1.1...v0.1.2) - 2025-03-21
+
+### Other
+
+- revert ver bumps
+- revert ver bumps
+- ver bump
+- with tests
+- send actual json serialized types
+- convenience derives
+- make payload optional
+- rm unrelated
+- provide js feat for transient dep
+- add metadata serde
+- with docs & using bin for raw
+- specify roundtrip format
+- consistent naming
+- use envelope
+- websocket data wrapper
+- pub envelope methods
+- pub codec for envelope
+
 ### Changed
 
 - Provided better transport types for Layer8Envelope. Includes `Layer8Envelope::Http`, `Layer8Envelope::WebSocket` and `Layer8Envelope::Raw`, the latter being a catch-all for any other transport type. [#7](https://github.com/globe-and-citizen/layer8-primitives-rs/pull/7)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "layer8-primitives"
-version = "0.1.2"
+version = "0.1.1"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "layer8-primitives"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "layer8-primitives"
-version = "0.2.0"
+version = "0.1.2"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "layer8-primitives"
-version = "0.2.0"
+version = "0.1.2"
 edition = "2021"
 authors = ["Osoro Bironga <fanosoro@gmail.com>"]
 repository = "https://github.com/globe-and-citizen/layer8-primitives-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "layer8-primitives"
-version = "0.1.2"
+version = "0.1.1"
 edition = "2021"
 authors = ["Osoro Bironga <fanosoro@gmail.com>"]
 repository = "https://github.com/globe-and-citizen/layer8-primitives-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "layer8-primitives"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Osoro Bironga <fanosoro@gmail.com>"]
 repository = "https://github.com/globe-and-citizen/layer8-primitives-rs"


### PR DESCRIPTION
## 🤖 New release
* `layer8-primitives`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/globe-and-citizen/layer8-primitives-rs/compare/v0.1.1...v0.1.2) - 2025-03-21

### Other

### Changed

- Provided better transport types for Layer8Envelope. Includes `Layer8Envelope::Http`, `Layer8Envelope::WebSocket` and `Layer8Envelope::Raw`, the latter being a catch-all for any other transport type. [#7](https://github.com/globe-and-citizen/layer8-primitives-rs/pull/7)
- `RoundtripEnvelope` API are now public. [#6](https://github.com/globe-and-citizen/layer8-primitives-rs/pull/6)

### Added

- Provided a structure for Websocket messages, `WebSocketPayload`. Added tests for the transport formats. [#7](https://github.com/globe-and-citizen/layer8-primitives-rs/pull/7)
- Pinning the getrandom version and including the `js` feature for compatibility with WebAssembly target consumers. [#9](https://github.com/globe-and-citizen/layer8-primitives-rs/pull/9)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).