### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/globe-and-citizen/layer8-primitives-rs/compare/v0.1.2...v0.2.0) - 2025-04-26
+
+### Other
+
+- Revert "upd: version bump ([#17](https://github.com/globe-and-citizen/layer8-primitives-rs/pull/17))" ([#18](https://github.com/globe-and-citizen/layer8-primitives-rs/pull/18))
+- version bump ([#17](https://github.com/globe-and-citizen/layer8-primitives-rs/pull/17))
+- use ubuntu latest ([#16](https://github.com/globe-and-citizen/layer8-primitives-rs/pull/16))
+- [**breaking**] splitting metadata from body ([#15](https://github.com/globe-and-citizen/layer8-primitives-rs/pull/15))
+
 ## [0.1.2](https://github.com/globe-and-citizen/layer8-primitives-rs/compare/v0.1.1...v0.1.2) - 2025-03-21
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "layer8-primitives"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "layer8-primitives"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 authors = ["Osoro Bironga <fanosoro@gmail.com>"]
 repository = "https://github.com/globe-and-citizen/layer8-primitives-rs"


### PR DESCRIPTION
## 🤖 New release
* `layer8-primitives`: 0.1.2 -> 0.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/globe-and-citizen/layer8-primitives-rs/compare/v0.1.2...v0.2.0) - 2025-04-26

### Other

- Revert "upd: version bump ([#17](https://github.com/globe-and-citizen/layer8-primitives-rs/pull/17))" ([#18](https://github.com/globe-and-citizen/layer8-primitives-rs/pull/18))
- version bump ([#17](https://github.com/globe-and-citizen/layer8-primitives-rs/pull/17))
- use ubuntu latest ([#16](https://github.com/globe-and-citizen/layer8-primitives-rs/pull/16))
- [**breaking**] splitting metadata from body ([#15](https://github.com/globe-and-citizen/layer8-primitives-rs/pull/15))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).