### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/globe-and-citizen/layer8-primitives-rs/compare/v0.2.0...v0.2.1) - 2025-05-11
+
+### Other
+
+- provide getter for proxyClient url ([#20](https://github.com/globe-and-citizen/layer8-primitives-rs/pull/20))
+
 ## [0.2.0](https://github.com/globe-and-citizen/layer8-primitives-rs/compare/v0.1.2...v0.2.0) - 2025-04-26
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "layer8-primitives"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "layer8-primitives"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Osoro Bironga <fanosoro@gmail.com>"]
 repository = "https://github.com/globe-and-citizen/layer8-primitives-rs"


### PR DESCRIPTION
## 🤖 New release
* `layer8-primitives`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/globe-and-citizen/layer8-primitives-rs/compare/v0.2.0...v0.2.1) - 2025-05-11

### Other

- provide getter for proxyClient url ([#20](https://github.com/globe-and-citizen/layer8-primitives-rs/pull/20))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).